### PR TITLE
Add CI step that builds docker image and pushes it to Docker Hub Repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,40 +29,40 @@ jobs:
         run: uv run pytest
 
   docker:
-  needs: test
-  runs-on: ubuntu-latest
-  # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-  
-  steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+    needs: test
+    runs-on: ubuntu-latest
+    # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      with:
-        version: v0.10.0
-        driver-opts: image=moby/buildkit:v0.11.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.10.0
+          driver-opts: image=moby/buildkit:v0.11.0
 
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: microlearningapp/microlearningapp-api
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: microlearningapp/microlearningapp-api
 
-    - name: Build and Push Docker image
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        provenance: true
-        sbom: true
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   docker:
     needs: test
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -27,3 +27,42 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  docker:
+  needs: test
+  runs-on: ubuntu-latest
+  # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+  
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        version: v0.10.0
+        driver-opts: image=moby/buildkit:v0.11.0
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: microlearningapp/microlearningapp-api
+
+    - name: Build and Push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        provenance: true
+        sbom: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.10.0
-          driver-opts: image=moby/buildkit:v0.11.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -64,5 +61,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=microlearningapp/microlearningapp-api:cache
           cache-to: type=registry,ref=microlearningapp/microlearningapp-api:cache,mode=max
-          provenance: true
-          sbom: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=microlearningapp/microlearningapp-api:cache
+          cache-to: type=registry,ref=microlearningapp/microlearningapp-api:cache,mode=max
           provenance: true
           sbom: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Use Python 3.12 slim image as base
 FROM python:3.12-slim
 
+# Don't write pycache files to disk
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 # Set working directory
 WORKDIR /app
 
@@ -10,14 +14,21 @@ RUN pip install uv
 # Copy dependency files
 COPY pyproject.toml uv.lock ./
 
-# Install dependencies
-RUN uv sync
+# Install production dependencies only
+RUN uv sync --frozen --no-dev
+
+# Create non-root user for security
+RUN groupadd -r appuser && useradd -r -g appuser appuser
 
 # Copy application code
 COPY . .
+
+# Change ownership to non-root user
+RUN chown -R appuser:appuser /app
+USER appuser
 
 # Expose port 8000 
 EXPOSE 8000
 
 # Command to run the application
-CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"] 
+CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## 📝 Description

- Adds docker job with associated steps to build and push image to our Docker Hub repository
- Modifies dockerfile to not run as root user when application is running
- Uses Docker Hub registry cache as our image cache to speed up builds 

---

## ✅ Type of Change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Code style update (formatting, renaming)
- [ ] Refactor (non-breaking change without new features)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Documentation update

---

## 🔍 How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Pipeline and verifying in Docker Hub that the image has been pushed. Currently this will run in the PR pipeline and if it works, will only have this run on main.
---

## 📸 Screenshots (if applicable)

---

## 🔗 Related Issues / PRs

List any related issues or pull requests:

---

## 📢 Checklist

- [ ] I followed the project's code style
- [ ] I reviewed my code before pushing
- [ ] I added tests that prove my fix is effective or my feature works
- [ ] I added/updated relevant documentation
- [ ] I linked related issues/PRs
